### PR TITLE
Fix load path for release CI task

### DIFF
--- a/govuk_web_banners.gemspec
+++ b/govuk_web_banners.gemspec
@@ -1,3 +1,5 @@
+$LOAD_PATH.push File.expand_path("lib", __dir__)
+
 require_relative "lib/govuk_web_banners/version"
 
 Gem::Specification.new do |spec|


### PR DESCRIPTION
- Release CI task can't infer base_path to require the version file, so we need to explicitly add lib.