### PR TITLE
Ready for auto-release

### DIFF
--- a/govuk_web_banners.gemspec
+++ b/govuk_web_banners.gemspec
@@ -13,10 +13,6 @@ Gem::Specification.new do |spec|
   spec.license     = "MIT"
   spec.required_ruby_version = ">= 3.1"
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the "allowed_push_host"
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
-
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://www.github.com/alphagov/govuk_web_banners"
   spec.metadata["changelog_uri"] = "https://www.github.com/alphagov/govuk_web_banners/CHANGELOG.md"

--- a/govuk_web_banners.gemspec
+++ b/govuk_web_banners.gemspec
@@ -1,6 +1,6 @@
 $LOAD_PATH.push File.expand_path("lib", __dir__)
 
-require_relative "lib/govuk_web_banners/version"
+require "govuk_web_banners/version"
 
 Gem::Specification.new do |spec|
   spec.name        = "govuk_web_banners"
@@ -21,9 +21,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://www.github.com/alphagov/govuk_web_banners"
   spec.metadata["changelog_uri"] = "https://www.github.com/alphagov/govuk_web_banners/CHANGELOG.md"
 
-  spec.files = Dir.chdir(File.expand_path(__dir__)) {
-    Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
-  }.reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"].reject { |f| f.match(/validators/) }
 
   spec.add_dependency "govuk_publishing_components"
   spec.add_dependency "rails", ">= 7"


### PR DESCRIPTION
- Now we have load path, we should use require from the lib root instead of require_relative
- Simplify spec.files (tests/specs are already not included, but we also want to exclude the validators from the deploy artifact)
- Remove the allowed_push_host directive.