### PR TITLE
Add global banner handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ Include a link to your pull request.
 When adding a new banner to gov.uk page, release a minor version.
 For typos, release a patch version.
 
-## Unreleased
+## UNRELEASED
 
+* Add global banner support ([PR #34](https://github.com/alphagov/govuk_web_banners/pull/34))
 * Remove configuration for "HMRC banner 03/01/2025" ([PR #53](https://github.com/alphagov/govuk_web_banners/pull/53))
 * Gem updates ([PR #50](https://github.com/alphagov/govuk_web_banners/pull/50))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (50.0.1)
+    govuk_publishing_components (51.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ Proof of Concept for centralising handling of Recruitment, Global, and Emergency
 banners (currently spread across apps)
 
 ## Usage
-Currently supports the emergency banner and recruitment banners.
 
 ## Adding the gem to your application
 Add this line to your application's Gemfile:
@@ -30,7 +29,13 @@ Add the JS dependencies to your existing asset dependencies file:
 
 ## Adding emergency banners
 
-Emergency banners are passed to the [Layout for Public](https://components.publishing.service.gov.uk/component-guide/layout_for_public) component, which is currently applied to each frontend app by the slimmer/static wrapping code - so you will only need to handle emergency banners in your app when Slimmer is removed from it. Once Slimmer is removed and you are calling the layout_for_public component directly in your app, add the emergency banner partial to the component's `emergency_banner:` key:
+Emergency banners are passed to the [Layout for
+Public](https://components.publishing.service.gov.uk/component-guide/layout_for_public)
+component, which is currently applied to each frontend app by the slimmer/static
+wrapping code - so you will only need to handle emergency banners in your app
+when Slimmer is removed from it. Once Slimmer is removed and you are calling the
+layout_for_public component directly in your app, add the emergency banner
+partial to the component's `emergency_banner:` key:
 
 ```
 <%= render "govuk_publishing_components/components/layout_for_public", {
@@ -40,7 +45,8 @@ Emergency banners are passed to the [Layout for Public](https://components.publi
   ...etc
 ```
 
-if you want the homepage variant of the banner, you can add `homepage: true` to the render call:
+if you want the homepage variant of the banner, you can add `homepage: true` to
+the render call:
 
 ```
 <%= render "govuk_publishing_components/components/layout_for_public", {
@@ -50,9 +56,16 @@ if you want the homepage variant of the banner, you can add `homepage: true` to 
   ...etc
 ```
 
-Your app will also need access to the whitehall shared redis cluster (which is used to signal the emergency banner is up), via the `EMERGENCY_BANNER_REDIS_URL` environment variable (here is an example of [setting this in govuk-helm-charts](https://github.com/alphagov/govuk-helm-charts/blob/7818eaa22fc194d21548f316bcc5a46c2023dcb6/charts/app-config/values-staging.yaml#L3337-L3338)). You'll need to allow this in all three environments.
+Your app will also need access to the whitehall shared redis cluster (which is
+used to signal the emergency banner is up), via the `EMERGENCY_BANNER_REDIS_URL`
+environment variable (here is an example of [setting this in
+govuk-helm-charts](https://github.com/alphagov/govuk-helm-charts/blob/7818eaa22fc194d21548f316bcc5a46c2023dcb6/charts/app-config/values-staging.yaml#L3337-L3338)).
+You'll need to allow this in all three environments.
 
-Finally, you'll need to configure a connection to the redis cluster, available at `Rails.application.config.emergency_banner_redis_client`. The suggested way of doing this is creating an initializer at `/config/initializers/govuk_web_banners.rb` with the content:
+Finally, you'll need to configure a connection to the redis cluster, available
+at `Rails.application.config.emergency_banner_redis_client`. The suggested way
+of doing this is creating an initializer at
+`/config/initializers/govuk_web_banners.rb` with the content:
 
 ```
 Rails.application.config.emergency_banner_redis_client = Redis.new(
@@ -61,11 +74,100 @@ Rails.application.config.emergency_banner_redis_client = Redis.new(
 )
 ```
 
+## Adding global banners
+
+Global banners are passed to the [Layout for
+Public](https://components.publishing.service.gov.uk/component-guide/layout_for_public)
+component, which is currently applied to each frontend app by the slimmer/static
+wrapping code - so you will only need to handle global banners in your app when
+Slimmer is removed from it. Once Slimmer is removed and you are calling the
+layout_for_public component directly in your app, add the global banner partial
+to the component's `global_banner:` key:
+
+```
+<%= render "govuk_publishing_components/components/layout_for_public", {
+  draft_watermark: draft_environment,
+  global_banner: render("govuk_web_banners/global_banner"), # <-- Add this line
+  full_width: false,
+  ...etc
+```
+
+## Updating banner information in the gem
+
+Data for the global banners can be found at
+`config/govuk_web_banners/global_banners.yml`. To add a banner to the config,
+add an entry under the banners: array. Note that this array must always be
+valid, so if there are no banners in the file, it must contain at least
+`global_banners: []`
+
+### Example banner entry
+
+```
+global_banners:
+- name: Banner 1
+  title: "Register to Vote"
+  title_href: /register-to-vote
+  text: "You must register to vote before the election"
+  permanent: false
+  exclude_paths:
+  - /find-your-local-electoral-office
+  start_date: 2024/10/21
+  end_date: 2024/11/18
+```
+Each banner must include a `title`, `title_href`, `text`, and a valid `start_date`.
+`title_href` can be either a valid URL or a path on gov.uk.
+
+> [!NOTE]
+>
+> `start_date` is **mandatory** here (unlike in recruitment banners) because it's
+> needed to create a banner_version to pass to the underlying component. This lets
+> the component reset the cookie that records how many times a banner has been seen
+> (by default banners are shown only three times, see the `permanent` option below.)
+
+Optional keys are:
+- `name` (an identifying name for this banner, not rendered
+  anywhere)
+- `permanent` (defaults to false. If false, banner is hidden if the user
+  has consented to cookies and has seen this banner more than 3 times)
+- `exclude_paths` an array of paths on which the banner should not be shown.
+  Note that the banner is never shown on the path it points to, this
+  list is to include any additional pages.
+- `end_date` (the banner stops being active at the *start* of the day
+  specified as `end_date`). Start and end dates must be in the YYYY/MM/DD
+  format parsable as a YAML -> Date.
+
+### Validations on the global banners config file
+
+The config file will be checked during CI, so an invalid file can't be released
+as a gem and we are nudged to make sure it's kept tidy. These checks include:
+
+* the global_banners array must be a valid YAML array
+* all banners have a `title`, `title_href`, and `info_text`.
+* all banners must have a valid `start_date`.
+
+It will also display warnings (but not fail CI)
+
+* if there are banners that have expired - you are encouraged to remove
+  obsolete config, but it will not prevent you merging changes.
+* if `title_href` of any banner points to a page that are not currently live on
+  GOV.UK - this may be intentional (if the banner points to a page that isn't
+  yet published), or it may indicate a typo in the path.
+* if any `exclude_paths` value points to a page that is not currently live on
+  GOV.UK - this may be intentional, or it may indicate a typo in the path.
+* if two global banners will be active on the same day (this is only a warning
+  because ultimately we may need this, but the current iteration of the
+  component does not support it)
+
+Note that some of this validation code is in the
+`/lib/govuk_web_banners/validators/global_banner.rb` file, which should be
+tested to ensure the checking is valid, but will not be bundled into the
+released gem.
+
 ## Adding recruitment banners
 
 Add a call to the partial in the layout or view that you want banners to appear
-in (typically recruitment banners should be in the layout, below the breadcrumbs
-and just above the `main` element):
+in (typically recruitment banners should be in the layout, below the
+breadcrumbs and just above the `main` element):
 
 ```
   <%= render "govuk_web_banners/recruitment_banner" %>
@@ -102,8 +204,8 @@ banners:
   page_paths:
   - /
   - /foreign-travel-advice
-  start_date: 21/10/2024
-  end_date: 18/11/2024
+  start_date: 2024/10/21
+  end_date: 2024/11/18
 ```
 
 The required keys are `suggestion_text`, `suggestion_link_text`, and
@@ -113,10 +215,10 @@ paths on which the banner should be shown).
 Optional keys are `name` (an identifying name for this banner, not rendered
 anywhere), and `start_date` / `end_date` (the banner becomes active at the start
 of the day specified as `start_date`, and stops at the *start* of the day
-specified as `end_date`). Start and end dates must be in the DD/MM/YYYY format
+specified as `end_date`). Start and end dates must be in the YYYY/MM/DD format
 parsable as a YAML -> Date.
 
-### Keeping the config file valid and tidy
+### Validations on the recruitment banners config file
 
 The config file will be checked during CI, so an invalid file can't be released
 as a gem and we are forced to make sure it's kept tidy. These checks include:
@@ -137,8 +239,9 @@ It will also display warnings (but not fail CI)
   may indicate a typo in the path.
 
 Note that some of this validation code is in the
-lib/govuk_web_banners/validators path, which should be tested to ensure the
-checking is valid, but will not be bundled into the released gem.
+`lib/govuk_web_banners/validator/recruitment_banner.rb` file, which should be
+tested to ensure the checking is valid, but will not be bundled into the
+released gem.
 
 ## License
 The gem is available as open source under the terms of the [MIT

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ require "bundler/gem_tasks"
 RuboCop::RakeTask.new
 RSpec::Core::RakeTask.new
 
+require "govuk_web_banners/validators/global_banner"
 require "govuk_web_banners/validators/recruitment_banner"
 require "rainbow"
 
@@ -36,7 +37,17 @@ def output_validator_info(validator, name)
   end
 end
 
-desc "show errors in the live config"
+desc "show errors in the live global banner config"
+task :check_global_config do
+  validator = GovukWebBanners::Validators::GlobalBanner.new(GovukWebBanners::GlobalBanner.all_banners)
+  output_validator_info(validator, "global banner")
+rescue StandardError => e
+  puts(e)
+  puts Rainbow("Live global banner config could not be read (if there are no banners, check global_banner key is marked as an empty array - global_banners: [])").red
+  exit(1)
+end
+
+desc "show errors in the live recruitment banner config"
 task :check_recruitment_config do
   validator = GovukWebBanners::Validators::RecruitmentBanner.new(GovukWebBanners::RecruitmentBanner.all_banners)
   output_validator_info(validator, "recruitment banner")
@@ -46,4 +57,4 @@ rescue StandardError => e
   exit(1)
 end
 
-task default: %i[check_recruitment_config rubocop spec]
+task default: %i[check_global_config check_recruitment_config rubocop spec]

--- a/Rakefile
+++ b/Rakefile
@@ -15,12 +15,9 @@ RSpec::Core::RakeTask.new
 require "govuk_web_banners/validators/recruitment_banner"
 require "rainbow"
 
-desc "show errors in the live config"
-task :check_config do
-  validator = GovukWebBanners::Validators::RecruitmentBanner.new(GovukWebBanners::RecruitmentBanner.all_banners)
-
+def output_validator_info(validator, name)
   if !validator.valid?
-    puts Rainbow("\nLive config contains errors!").red
+    puts Rainbow("\nLive #{name} config contains errors!").red
     validator.errors.each_key do |key|
       puts(key)
       validator.errors[key].each { |error| puts(" - #{error}") }
@@ -28,19 +25,25 @@ task :check_config do
     puts
     exit(1)
   elsif validator.warnings?
-    puts Rainbow("\nLive config is valid, but with warnings").yellow
+    puts Rainbow("\nLive #{name} config is valid, but with warnings").yellow
     validator.warnings.each_key do |key|
       puts(key)
       validator.warnings[key].each { |warnings| puts(" - #{warnings}") }
     end
     puts
   else
-    puts Rainbow("\nLive config is valid!\n").green
+    puts Rainbow("\nLive #{name} config is valid!\n").green
   end
+end
+
+desc "show errors in the live config"
+task :check_recruitment_config do
+  validator = GovukWebBanners::Validators::RecruitmentBanner.new(GovukWebBanners::RecruitmentBanner.all_banners)
+  output_validator_info(validator, "recruitment banner")
 rescue StandardError => e
   puts(e)
-  puts("Live config could not be read (if there are no banners, check banner key is marked as an empty array - banners: [])")
+  puts Rainbow("Live recruitment banner config could not be read (if there are no banners, check banner key is marked as an empty array - banners: [])").red
   exit(1)
 end
 
-task default: %i[check_config rubocop spec]
+task default: %i[check_recruitment_config rubocop spec]

--- a/app/views/govuk_web_banners/_global_banner.html.erb
+++ b/app/views/govuk_web_banners/_global_banner.html.erb
@@ -1,0 +1,10 @@
+<% global_banners = GovukWebBanners::GlobalBanner.for_path(request.path) %>
+<% if global_banners.any? %>
+  <%= render "govuk_publishing_components/components/global_banner", {
+      title: global_banners.first.title,
+      title_path: global_banners.first.title_href,
+      text: global_banners.first.text,
+      permanent: global_banners.first.permanent,
+      banner_version: global_banners.first.version,
+  } %>
+<% end %>

--- a/config/govuk_web_banners/global_banners.yml
+++ b/config/govuk_web_banners/global_banners.yml
@@ -1,0 +1,2 @@
+# Check README.md for how to format this file
+global_banners: []

--- a/config/govuk_web_banners/recruitment_banners.yml
+++ b/config/govuk_web_banners/recruitment_banners.yml
@@ -1,22 +1,6 @@
-# Example usage of adding a banner to the banners list
-
-  # banners:
-  # - name: Banner 1
-  #   suggestion_text: "Help improve GOV.UK"
-  #   suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"
-  #   survey_url: https://google.com
-  #   page_paths:
-  #   - /
-  #   - /foreign-travel-advice
-  #   start_date: 21/10/2024
-  #   end_date: 18/11/2024
-
-# start_date and end_date are optional, everything else is mandatory.
-#
-# Note that this file must contain a valid banners array, so if there are no banners
-# currently included, the file should at least contain banners: []
+# Check README.md for how to format this file
 banners:
-- name: UKVI banner 30/12/2025
+- name: UKVI banner 2025/12/30
   suggestion_text: "Help improve GOV.UK"
   suggestion_link_text: "Take part in user research (opens in a new tab)"
   survey_url: https://surveys.publishing.service.gov.uk/s/XYVRGN/
@@ -26,5 +10,5 @@ banners:
     # collections
     - /browse/visas-immigration
     - /government/organisations/uk-visas-and-immigration
-  start_date: 30/12/2024
-  end_date: 24/02/2025
+  start_date: 2024/12/30
+  end_date: 2025/02/24

--- a/lib/govuk_web_banners.rb
+++ b/lib/govuk_web_banners.rb
@@ -6,4 +6,5 @@ require "govuk_web_banners/recruitment_banner"
 require "govuk_web_banners/version"
 
 module GovukWebBanners
+  TIME_ZONE = "London".freeze
 end

--- a/lib/govuk_web_banners.rb
+++ b/lib/govuk_web_banners.rb
@@ -1,5 +1,6 @@
 require "govuk_publishing_components"
 
+require "govuk_web_banners/global_banner"
 require "govuk_web_banners/emergency_banner"
 require "govuk_web_banners/engine"
 require "govuk_web_banners/recruitment_banner"

--- a/lib/govuk_web_banners/global_banner.rb
+++ b/lib/govuk_web_banners/global_banner.rb
@@ -1,0 +1,46 @@
+module GovukWebBanners
+  class GlobalBanner
+    BANNER_CONFIG_FILE = "../../config/govuk_web_banners/global_banners.yml".freeze
+
+    def self.for_path(path)
+      active_banners.reject { |b| b.exclude_paths.include?(path) }
+    end
+
+    def self.active_banners
+      all_banners.select(&:active?)
+    end
+
+    def self.all_banners
+      global_banners_file_path = Rails.root.join(__dir__, BANNER_CONFIG_FILE)
+      global_banners_data = YAML.load_file(global_banners_file_path)
+      global_banners_data["global_banners"].map { |attributes| GlobalBanner.new(attributes:) }
+    end
+
+    attr_reader :name, :title, :title_href, :text, :start_date, :end_date, :show_arrows, :permanent, :exclude_paths
+
+    def initialize(attributes:)
+      @name = attributes["name"]
+
+      @title = attributes["title"]
+      @title_href = attributes["title_href"]
+      @text = attributes["text"]
+
+      @start_date = attributes["start_date"] ? ActiveSupport::TimeZone[GovukWebBanners::TIME_ZONE].parse(attributes["start_date"]) : nil
+      @end_date = attributes["end_date"] ? ActiveSupport::TimeZone[GovukWebBanners::TIME_ZONE].parse(attributes["end_date"]) : Time.now + 10.years
+      @show_arrows = attributes["show_arrows"] == "true"
+      @permanent = attributes["permanent"] == "true"
+      @exclude_paths = attributes["exclude_paths"] || []
+      @exclude_paths << title_href if title_href&.start_with?("/")
+    end
+
+    # NB: .between? is inclusive. To make it exclude the end date, we set the end range as
+    #     1 second earlier.
+    def active?
+      Time.zone.now.between?(start_date, end_date - 1.second)
+    end
+
+    def version
+      start_date.getutc.to_i
+    end
+  end
+end

--- a/lib/govuk_web_banners/recruitment_banner.rb
+++ b/lib/govuk_web_banners/recruitment_banner.rb
@@ -26,8 +26,8 @@ module GovukWebBanners
       @suggestion_link_text = attributes["suggestion_link_text"]
       @survey_url = attributes["survey_url"]
       @page_paths = attributes["page_paths"]
-      @start_date = attributes["start_date"] ? Time.parse(attributes["start_date"]) : Time.at(0)
-      @end_date = attributes["end_date"] ? Time.parse(attributes["end_date"]) : Time.now + 10.years
+      @start_date = attributes["start_date"] ? ActiveSupport::TimeZone[GovukWebBanners::TIME_ZONE].parse(attributes["start_date"]) : Time.at(0)
+      @end_date = attributes["end_date"] ? ActiveSupport::TimeZone[GovukWebBanners::TIME_ZONE].parse(attributes["end_date"]) : Time.now + 10.years
     end
 
     # NB: .between? is inclusive. To make it exclude the end date, we set the end range as

--- a/lib/govuk_web_banners/validators/base.rb
+++ b/lib/govuk_web_banners/validators/base.rb
@@ -1,0 +1,45 @@
+module GovukWebBanners
+  module Validators
+    class Base
+      attr_reader :errors, :warnings
+
+      def initialize(banners)
+        @errors = {}
+        @warnings = {}
+
+        validate(banners)
+      end
+
+      def valid?
+        @errors.keys.none?
+      end
+
+      def warnings?
+        @warnings.keys.any?
+      end
+
+    private
+
+      def add_error(banner, error)
+        @errors[safe_name(banner)] ||= []
+        @errors[safe_name(banner)] << error
+      end
+
+      def add_warning(banner, warning)
+        @warnings[safe_name(banner)] ||= []
+        @warnings[safe_name(banner)] << warning
+      end
+
+      def safe_name(banner)
+        banner.name || "unnamed banner"
+      end
+
+      def overlap?(banner, other_banner)
+        return false unless banner.start_date && other_banner.start_date
+
+        other_banner.start_date < banner.end_date &&
+          other_banner.end_date > banner.start_date
+      end
+    end
+  end
+end

--- a/lib/govuk_web_banners/validators/global_banner.rb
+++ b/lib/govuk_web_banners/validators/global_banner.rb
@@ -1,0 +1,51 @@
+require "active_support/core_ext/integer/time"
+require "open-uri"
+
+require "govuk_web_banners/validators/base"
+
+module GovukWebBanners
+  module Validators
+    class GlobalBanner < GovukWebBanners::Validators::Base
+    private
+
+      def validate(banners)
+        banners.each do |banner|
+          add_error(banner, "is missing a title") unless banner.title.present?
+          add_error(banner, "is missing a title_href") unless banner.title_href.present?
+          add_error(banner, "is missing a text") unless banner.text.present?
+
+          if banner.title_href&.start_with?("/")
+            begin
+              URI.open("https://www.gov.uk/api/content#{banner.title_href}")
+            rescue OpenURI::HTTPError
+              add_warning(banner, "refers to a path #{banner.title_href} which is not currently live on gov.uk")
+            end
+          end
+
+          if banner.start_date.present?
+            add_error(banner, "start_date is after end_date") unless banner.start_date < banner.end_date
+          else
+            add_error(banner, "is missing a start_date")
+          end
+
+          other_banners = banners - [banner]
+          other_banners.each do |other_banner|
+            add_warning(banner, "is active at the same time as #{safe_name(other_banner)}") if overlap?(banner, other_banner)
+          end
+
+          banner.exclude_paths.each do |exclude_path|
+            if exclude_path.start_with?("/")
+              URI.open("https://www.gov.uk/api/content#{exclude_path}")
+            else
+              add_error(banner, "exclude_path #{exclude_path} should start with a /")
+            end
+          rescue OpenURI::HTTPError
+            add_warning(banner, "refers to an exclude_path #{exclude_path} which is not currently live on gov.uk")
+          end
+
+          add_warning(banner, "is expired") unless banner.end_date >= Time.now
+        end
+      end
+    end
+  end
+end

--- a/lib/govuk_web_banners/validators/recruitment_banner.rb
+++ b/lib/govuk_web_banners/validators/recruitment_banner.rb
@@ -14,6 +14,7 @@ module GovukWebBanners
           add_error(banner, "is missing a suggestion_link_text") unless banner.suggestion_link_text.present?
           add_error(banner, "is missing a survey_url") unless banner.survey_url.present?
           add_error(banner, "is missing any page_paths") unless banner.page_paths.present?
+          add_error(banner, "start_date is after end_date") unless banner.start_date < banner.end_date
 
           (banner.page_paths || []).each do |path|
             if path.start_with?("/")

--- a/lib/govuk_web_banners/validators/recruitment_banner.rb
+++ b/lib/govuk_web_banners/validators/recruitment_banner.rb
@@ -1,41 +1,12 @@
 require "active_support/core_ext/integer/time"
 require "open-uri"
 
+require "govuk_web_banners/validators/base"
+
 module GovukWebBanners
   module Validators
-    class RecruitmentBanner
-      attr_reader :errors, :warnings
-
-      def initialize(banners)
-        @errors = {}
-        @warnings = {}
-
-        validate(banners)
-      end
-
-      def valid?
-        @errors.keys.none?
-      end
-
-      def warnings?
-        @warnings.keys.any?
-      end
-
+    class RecruitmentBanner < GovukWebBanners::Validators::Base
     private
-
-      def add_error(banner, error)
-        @errors[safe_name(banner)] ||= []
-        @errors[safe_name(banner)] << error
-      end
-
-      def add_warning(banner, warning)
-        @warnings[safe_name(banner)] ||= []
-        @warnings[safe_name(banner)] << warning
-      end
-
-      def safe_name(banner)
-        banner.name || "unnamed banner"
-      end
 
       def validate(banners)
         banners.each do |banner|
@@ -65,11 +36,6 @@ module GovukWebBanners
 
           add_warning(banner, "is expired") unless banner.end_date >= Time.now
         end
-      end
-
-      def overlap?(banner, other_banner)
-        other_banner.start_date < banner.end_date &&
-          other_banner.end_date > banner.start_date
       end
     end
   end

--- a/spec/dummy/app/views/banner_pages/global.html.erb
+++ b/spec/dummy/app/views/banner_pages/global.html.erb
@@ -1,0 +1,4 @@
+<%= render "govuk_publishing_components/components/layout_for_public", {
+    global_banner: render("govuk_web_banners/global_banner")
+  }
+%>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -7,4 +7,8 @@ Rails.application.routes.draw do
 
   get "/emergency", to: "banner_pages#emergency"
   get "/", to: "banner_pages#emergency_on_homepage"
+
+  get "/global", to: "banner_pages#global"
+  get "/global-linked-to", to: "banner_pages#global"
+  get "/global-related-to", to: "banner_pages#global"
 end

--- a/spec/fixtures/active_global_banners.yml
+++ b/spec/fixtures/active_global_banners.yml
@@ -1,0 +1,9 @@
+global_banners:
+- name: Active Banner
+  title: Here is a global message
+  title_href: /global-linked-to
+  text: You should click this link
+  start_date: 2025/01/02
+  exclude_paths:
+  - /global-related-to
+

--- a/spec/fixtures/empty_global_banners.yml
+++ b/spec/fixtures/empty_global_banners.yml
@@ -1,0 +1,1 @@
+global_banners: []

--- a/spec/fixtures/expired_global_banners.yml
+++ b/spec/fixtures/expired_global_banners.yml
@@ -1,0 +1,7 @@
+global_banners:
+- name: Expired Banner
+  title: Something
+  title_href: /global-linked-to
+  text: You should click this link
+  start_date: 2023/12/24
+  end_date: 2023/12/25

--- a/spec/fixtures/expired_recruitment_banners.yml
+++ b/spec/fixtures/expired_recruitment_banners.yml
@@ -1,4 +1,4 @@
-# Fixture - a banner that has already expired as of 01/01/2025
+# Fixture - a banner that has already expired as of 2025/01/01
 banners:
 - name: Banner 1
   suggestion_text: "Help improve GOV.UK"
@@ -7,4 +7,4 @@ banners:
   page_paths:
   - /
   - /foreign-travel-advice
-  end_date: 25/12/2023
+  end_date: 2023/12/25

--- a/spec/fixtures/invalid_global_banners.yml
+++ b/spec/fixtures/invalid_global_banners.yml
@@ -1,0 +1,36 @@
+global_banners:
+- name: Banner without title_href
+  title: Something
+  info_text: You should click this link
+  start_date: 2025/1/1
+  end_date: 2025/1/2
+- name: Banner without title
+  title_href: /hello
+  text: You should click this link
+  start_date: 2025/1/3
+  end_date: 2025/1/4
+- name: Banner without text
+  title: Something
+  title_href: /hello
+  start_date: 2025/1/4
+  end_date: 2025/1/5
+- name: Invalid exclude_path
+  title: Something
+  title_href: https://www.google.com
+  text: You should click this link
+  start_date: 2025/1/5
+  end_date: 2025/1/6
+  exclude_paths:
+  - hello
+- name: Dates inverted
+  title: Something
+  title_href: /hello
+  text: You should click this link
+  end_date: 2025/1/6
+  start_date: 2025/1/7
+- name: Missing start_date
+  title: Something
+  title_href: /hello
+  text: You should click this link
+  end_date: 2025/1/8
+

--- a/spec/fixtures/invalid_recruitment_banners.yml
+++ b/spec/fixtures/invalid_recruitment_banners.yml
@@ -32,3 +32,11 @@ banners:
   - /views
   - views/old
   - /views/new
+- name: Dates inverted
+  suggestion_text: "Help improve GOV.UK"
+  suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"
+  survey_url: https://google.com
+  page_paths:
+  - /news
+  end_date: 2025/01/06
+  start_date: 2025/01/07

--- a/spec/fixtures/path_clash_different_times_recruitment_banners.yml
+++ b/spec/fixtures/path_clash_different_times_recruitment_banners.yml
@@ -6,13 +6,13 @@ banners:
   survey_url: https://google.com
   page_paths:
   - /page-1
-  start_date: 12/02/2025
-  end_date: 12/04/2025
+  start_date: 2025/02/12
+  end_date: 2025/04/12
 - name: Banner may-aug
   suggestion_text: "Help improve GOV.UK"
   suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"
   survey_url: https://google.com
   page_paths:
   - /page-1
-  start_date: 12/04/2025
-  end_date: 12/08/2025
+  start_date: 2025/04/12
+  end_date: 2025/08/12

--- a/spec/fixtures/path_clash_same_time_recruitment_banners.yml
+++ b/spec/fixtures/path_clash_same_time_recruitment_banners.yml
@@ -6,13 +6,13 @@ banners:
   survey_url: https://google.com
   page_paths:
   - /page-1
-  start_date: 12/02/2025
-  end_date: 12/04/2025
+  start_date: 2025/02/12
+  end_date: 2025/04/12
 - name: Banner jan-mar
   suggestion_text: "Help improve GOV.UK"
   suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"
   survey_url: https://google.com
   page_paths:
   - /page-1
-  start_date: 12/01/2025
-  end_date: 12/03/2025
+  start_date: 2025/01/12
+  end_date: 2025/03/12

--- a/spec/fixtures/same_time_global_banners.yml
+++ b/spec/fixtures/same_time_global_banners.yml
@@ -1,0 +1,13 @@
+global_banners:
+- name: Banner feb-apr
+  title: Something
+  title_href: /global-linked-to
+  text: You should click this link
+  start_date: 2025/2/12
+  end_date: 2025/4/12
+- name: Banner jan-mar
+  title: Something
+  title_href: /global-linked-to
+  text: You should click this link
+  start_date: 2025/1/12
+  end_date: 2025/3/12

--- a/spec/fixtures/timed_global_banners.yml
+++ b/spec/fixtures/timed_global_banners.yml
@@ -1,0 +1,20 @@
+# Fixture - valid global_banners with time restrictions
+global_banners:
+- name: Banner jan-mar
+  title: Something
+  title_href: /global-linked-to
+  text: You should click this link
+  start_date: 2025/1/12
+  end_date: 2025/3/12
+- name: Banner feb-apr
+  title: Something
+  title_href: /global-linked-to
+  text: You should click this link
+  start_date: 2025/2/12
+  end_date: 2025/4/12
+- name: Banner apr-may
+  title: Something
+  title_href: /global-linked-to
+  text: You should click this link
+  start_date: 2025/4/12
+  end_date: 2025/5/12

--- a/spec/fixtures/timed_recruitment_banners.yml
+++ b/spec/fixtures/timed_recruitment_banners.yml
@@ -6,30 +6,30 @@ banners:
   survey_url: https://google.com
   page_paths:
   - /page-1
-  start_date: 01/01/2025
+  start_date: 2025/01/01
 - name: banner with no start_date
   suggestion_text: "Help improve GOV.UK"
   suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"
   survey_url: https://google.com
   page_paths:
   - /page-2
-  end_date: 01/01/2025
+  end_date: 2025/01/01
 - name: Banner with start and end date
   suggestion_text: "Help improve GOV.UK"
   suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"
   survey_url: https://google.com
   page_paths:
   - /page-3
-  start_date: 01/01/2025
-  end_date: 01/02/2025
+  start_date: 2025/01/01
+  end_date: 2025/02/01
 - name: Banner with start and end date abutting previous banner
   suggestion_text: "Help improve GOV.UK"
   suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"
   survey_url: https://google.com
   page_paths:
   - /page-3
-  start_date: 01/02/2025
-  end_date: 01/03/2025
+  start_date: 2025/02/01
+  end_date: 2025/03/01
 - name: Banner with no dates
   suggestion_text: "Help improve GOV.UK"
   suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"

--- a/spec/requests/global_banner_spec.rb
+++ b/spec/requests/global_banner_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe "Global Banners" do
+  before do
+    original_path = Rails.root.join(__dir__, GovukWebBanners::GlobalBanner::BANNER_CONFIG_FILE)
+    allow(YAML).to receive(:load_file).with(original_path).and_return(replacement_file)
+  end
+
+  context "when visiting a page which includes the global banner partial" do
+    context "and the a banner is active" do
+      let(:replacement_file) do
+        YAML.load_file(Rails.root.join(__dir__, "../../spec/fixtures/active_global_banners.yml"))
+      end
+
+      it "shows the banner on the page" do
+        get "/global"
+
+        expect(response.body).to include("Here is a global message")
+      end
+
+      it "does not show the banner on the page the banner links to" do
+        get "/global-linked-to"
+
+        expect(response.body).not_to include("Here is a global message")
+      end
+
+      it "does not show the banner on a page in the except_paths list" do
+        get "/global-related-to"
+
+        expect(response.body).not_to include("Here is a global message")
+      end
+    end
+
+    context "but no banner is active" do
+      let(:replacement_file) do
+        YAML.load_file(Rails.root.join(__dir__, "../../spec/fixtures/empty_global_banners.yml"))
+      end
+
+      it "does not show the banner on the page" do
+        get "/global"
+
+        expect(response.body).not_to include("Here is a global message")
+      end
+    end
+  end
+end

--- a/spec/units/govuk_web_banners/global_banner_spec.rb
+++ b/spec/units/govuk_web_banners/global_banner_spec.rb
@@ -1,0 +1,95 @@
+RSpec.describe GovukWebBanners::GlobalBanner do
+  let(:fixtures_dir) { Rails.root.join(__dir__, "../../fixtures/") }
+
+  before do
+    original_path = Rails.root.join(__dir__, "../", described_class::BANNER_CONFIG_FILE)
+    allow(YAML).to receive(:load_file).with(original_path).and_return(replacement_file)
+  end
+
+  describe ".for_path" do
+    context "with banners" do
+      let(:replacement_file) do
+        YAML.load_file(Rails.root.join(fixtures_dir, "active_global_banners.yml"))
+      end
+
+      it "returns array with the banner for a random path" do
+        expect(described_class.for_path("/foreign-travel-advice").count).to eq(1)
+        expect(described_class.for_path("/foreign-travel-advice").first).to be_instance_of(described_class)
+      end
+
+      it "returns empty array the path the banner links to" do
+        expect(described_class.for_path("/global-linked-to")).to be_empty
+      end
+
+      it "returns empty array for a path in excluded_paths" do
+        expect(described_class.for_path("/global-related-to")).to be_empty
+      end
+    end
+
+    context "with timed global banners" do
+      let(:replacement_file) do
+        YAML.load_file(Rails.root.join(fixtures_dir, "timed_global_banners.yml"))
+      end
+
+      after { travel_back }
+
+      context "but before timed global banners are active" do
+        before { travel_to Time.local(2024, 12, 31) }
+
+        it "finds only banners with no start time" do
+          expect(described_class.for_path("/")).to be_empty
+        end
+      end
+
+      context "and on the day january banner becomes active" do
+        before { travel_to Time.local(2025, 1, 12) }
+
+        it "finds one banner active on that date" do
+          expect(described_class.for_path("/").count).to eq(1)
+          expect(described_class.for_path("/").first.name).to eq("Banner jan-mar")
+          expect(described_class.for_path("/").first.version).to eq(1_736_640_000)
+        end
+      end
+
+      context "and on the day feb banner becomes active" do
+        before { travel_to Time.local(2025, 2, 12) }
+
+        it "finds both banners active on that date" do
+          expect(described_class.for_path("/").count).to eq(2)
+          expect(described_class.for_path("/").first.name).to eq("Banner jan-mar")
+          expect(described_class.for_path("/").first.version).to eq(1_736_640_000)
+          expect(described_class.for_path("/").second.name).to eq("Banner feb-apr")
+          expect(described_class.for_path("/").second.version).to eq(1_739_318_400)
+        end
+      end
+
+      context "and on the day jan banner becomes inactive" do
+        before { travel_to Time.local(2025, 3, 12) }
+
+        it "finds both banners active on that date" do
+          expect(described_class.for_path("/").count).to eq(1)
+          expect(described_class.for_path("/").first.name).to eq("Banner feb-apr")
+          expect(described_class.for_path("/").first.version).to eq(1_739_318_400)
+        end
+      end
+
+      context "and on the day feb banner swaps to apr banner" do
+        before { travel_to Time.local(2025, 4, 12) }
+
+        it "finds both banners active on that date" do
+          expect(described_class.for_path("/").count).to eq(1)
+          expect(described_class.for_path("/").first.name).to eq("Banner apr-may")
+          expect(described_class.for_path("/").first.version).to eq(1_744_412_400)
+        end
+      end
+
+      context "but after all timed banners end" do
+        before { travel_to Time.local(2025, 5, 12) }
+
+        it "finds no banners active" do
+          expect(described_class.for_path("/")).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/units/govuk_web_banners/validators/global_banner_spec.rb
+++ b/spec/units/govuk_web_banners/validators/global_banner_spec.rb
@@ -1,0 +1,140 @@
+require "govuk_web_banners/validators/global_banner"
+
+RSpec.describe GovukWebBanners::Validators::GlobalBanner do
+  subject(:validator) { described_class.new(GovukWebBanners::GlobalBanner.all_banners) }
+
+  let(:fixtures_dir) { Rails.root.join(__dir__, "../../../../spec/fixtures/") }
+
+  before do
+    original_path = Rails.root.join(__dir__, "../../", GovukWebBanners::GlobalBanner::BANNER_CONFIG_FILE)
+    allow(YAML).to receive(:load_file).with(original_path).and_return(replacement_file)
+
+    stub_request(:get, %r{\Ahttps://www\.gov\.uk/api/content/.*})
+  end
+
+  context "with valid banners" do
+    let(:replacement_file) do
+      YAML.load_file(Rails.root.join(fixtures_dir, "active_global_banners.yml"))
+    end
+
+    describe ".valid?" do
+      it "returns true" do
+        expect(validator.valid?).to be true
+      end
+    end
+
+    describe "errors attribute" do
+      it "returns an empty array" do
+        expect(validator.errors).to be_empty
+      end
+    end
+  end
+
+  context "with invalid banners" do
+    let(:replacement_file) do
+      YAML.load_file(Rails.root.join(fixtures_dir, "invalid_global_banners.yml"))
+    end
+
+    describe ".valid?" do
+      it "returns false" do
+        expect(validator.valid?).to be false
+      end
+    end
+
+    describe "errors attribute" do
+      it "returns the relevant errors" do
+        expect(validator.errors["Banner without title_href"]).to include("is missing a title_href")
+        expect(validator.errors["Banner without title"]).to include("is missing a title")
+        expect(validator.errors["Banner without text"]).to include("is missing a text")
+        expect(validator.errors["Invalid exclude_path"]).to include("exclude_path hello should start with a /")
+        expect(validator.errors["Dates inverted"]).to include("start_date is after end_date")
+        expect(validator.errors["Missing start_date"]).to include("is missing a start_date")
+      end
+    end
+  end
+
+  context "with a banner that has expired" do
+    let(:replacement_file) do
+      YAML.load_file(Rails.root.join(fixtures_dir, "expired_global_banners.yml"))
+    end
+
+    before { travel_to Time.local(2024, 1, 2) }
+    after { travel_back }
+
+    describe ".valid?" do
+      it "returns true" do
+        expect(validator.valid?).to be true
+      end
+    end
+
+    describe ".warnings?" do
+      it "returns true" do
+        expect(validator.warnings?).to be true
+      end
+    end
+
+    describe "warnings attribute" do
+      it "returns the relevant warnings" do
+        expect(validator.warnings).to eq({ "Expired Banner" => ["is expired"] })
+      end
+    end
+  end
+
+  context "with banners that are active at the same time" do
+    context "when they are active at the same time" do
+      let(:replacement_file) do
+        YAML.load_file(Rails.root.join(fixtures_dir, "same_time_global_banners.yml"))
+      end
+
+      describe ".valid?" do
+        it "returns true" do
+          expect(validator.valid?).to be true
+        end
+      end
+
+      describe ".warnings?" do
+        it "returns true" do
+          expect(validator.warnings?).to be true
+        end
+      end
+
+      describe "warnings attribute" do
+        it "returns the relevant warnings" do
+          expect(validator.warnings["Banner feb-apr"]).to eq(["is active at the same time as Banner jan-mar"])
+          expect(validator.warnings["Banner jan-mar"]).to eq(["is active at the same time as Banner feb-apr"])
+        end
+      end
+    end
+  end
+
+  context "with a path that doesn't exist on the live site" do
+    let(:replacement_file) do
+      YAML.load_file(Rails.root.join(fixtures_dir, "active_global_banners.yml"))
+    end
+
+    before do
+      stub_request(:get, %r{\Ahttps://www\.gov\.uk/api/content/global-linked-to}).to_return(status: 404)
+    end
+
+    describe ".valid?" do
+      it "returns true" do
+        expect(validator.valid?).to be true
+      end
+    end
+
+    describe ".warnings?" do
+      it "returns true" do
+        expect(validator.warnings?).to be true
+      end
+    end
+
+    describe "warnings attribute" do
+      it "returns the relevant warnings" do
+        expect(validator.warnings).to eq({ "Active Banner" => [
+          "refers to a path /global-linked-to which is not currently live on gov.uk",
+          "refers to an exclude_path /global-linked-to which is not currently live on gov.uk",
+        ] })
+      end
+    end
+  end
+end

--- a/spec/units/govuk_web_banners/validators/recruitment_banner_spec.rb
+++ b/spec/units/govuk_web_banners/validators/recruitment_banner_spec.rb
@@ -1,7 +1,7 @@
 require "govuk_web_banners/validators/recruitment_banner"
 
 RSpec.describe GovukWebBanners::Validators::RecruitmentBanner do
-  subject(:recruitment_banner) { described_class.new(GovukWebBanners::RecruitmentBanner.all_banners) }
+  subject(:validator) { described_class.new(GovukWebBanners::RecruitmentBanner.all_banners) }
 
   let(:fixtures_dir) { Rails.root.join(__dir__, "../../../../spec/fixtures/") }
 
@@ -19,13 +19,13 @@ RSpec.describe GovukWebBanners::Validators::RecruitmentBanner do
 
     describe ".valid?" do
       it "returns true" do
-        expect(recruitment_banner.valid?).to be true
+        expect(validator.valid?).to be true
       end
     end
 
     describe "errors attribute" do
       it "returns an empty array" do
-        expect(recruitment_banner.errors).to be_empty
+        expect(validator.errors).to be_empty
       end
     end
   end
@@ -37,17 +37,18 @@ RSpec.describe GovukWebBanners::Validators::RecruitmentBanner do
 
     describe ".valid?" do
       it "returns false" do
-        expect(recruitment_banner.valid?).to be false
+        expect(validator.valid?).to be false
       end
     end
 
     describe "errors attribute" do
       it "returns the relevant errors" do
-        expect(recruitment_banner.errors["Empty Survey URL"]).to eq(["is missing a survey_url"])
-        expect(recruitment_banner.errors["Suggestion Link Text Broken"]).to eq(["is missing a suggestion_link_text"])
-        expect(recruitment_banner.errors["Page Paths Empty"]).to eq(["is missing any page_paths"])
-        expect(recruitment_banner.errors["Suggestion Text Empty"]).to eq(["is missing a suggestion_text"])
-        expect(recruitment_banner.errors["Page Paths include invalid path"]).to eq(["page_path views/old should start with a /"])
+        expect(validator.errors["Empty Survey URL"]).to eq(["is missing a survey_url"])
+        expect(validator.errors["Suggestion Link Text Broken"]).to eq(["is missing a suggestion_link_text"])
+        expect(validator.errors["Page Paths Empty"]).to eq(["is missing any page_paths"])
+        expect(validator.errors["Suggestion Text Empty"]).to eq(["is missing a suggestion_text"])
+        expect(validator.errors["Page Paths include invalid path"]).to eq(["page_path views/old should start with a /"])
+        expect(validator.errors["Dates inverted"]).to eq(["start_date is after end_date"])
       end
     end
   end
@@ -62,19 +63,19 @@ RSpec.describe GovukWebBanners::Validators::RecruitmentBanner do
 
     describe ".valid?" do
       it "returns true" do
-        expect(recruitment_banner.valid?).to be true
+        expect(validator.valid?).to be true
       end
     end
 
     describe ".warnings?" do
       it "returns true" do
-        expect(recruitment_banner.warnings?).to be true
+        expect(validator.warnings?).to be true
       end
     end
 
     describe "warnings attribute" do
       it "returns the relevant warnings" do
-        expect(recruitment_banner.warnings).to eq({ "Banner 1" => ["is expired"] })
+        expect(validator.warnings).to eq({ "Banner 1" => ["is expired"] })
       end
     end
   end
@@ -87,13 +88,13 @@ RSpec.describe GovukWebBanners::Validators::RecruitmentBanner do
 
       describe ".valid?" do
         it "returns true" do
-          expect(recruitment_banner.valid?).to be true
+          expect(validator.valid?).to be true
         end
       end
 
       describe "errors attribute" do
         it "returns an empty array" do
-          expect(recruitment_banner.errors).to be_empty
+          expect(validator.errors).to be_empty
         end
       end
     end
@@ -105,14 +106,14 @@ RSpec.describe GovukWebBanners::Validators::RecruitmentBanner do
 
       describe ".valid?" do
         it "returns false" do
-          expect(recruitment_banner.valid?).to be false
+          expect(validator.valid?).to be false
         end
       end
 
       describe "errors attribute" do
         it "returns the relevant errors" do
-          expect(recruitment_banner.errors["Banner feb-apr"]).to eq(["is active at the same time as Banner jan-mar and points to the same paths"])
-          expect(recruitment_banner.errors["Banner jan-mar"]).to eq(["is active at the same time as Banner feb-apr and points to the same paths"])
+          expect(validator.errors["Banner feb-apr"]).to eq(["is active at the same time as Banner jan-mar and points to the same paths"])
+          expect(validator.errors["Banner jan-mar"]).to eq(["is active at the same time as Banner feb-apr and points to the same paths"])
         end
       end
     end
@@ -129,19 +130,19 @@ RSpec.describe GovukWebBanners::Validators::RecruitmentBanner do
 
     describe ".valid?" do
       it "returns true" do
-        expect(recruitment_banner.valid?).to be true
+        expect(validator.valid?).to be true
       end
     end
 
     describe ".warnings?" do
       it "returns true" do
-        expect(recruitment_banner.warnings?).to be true
+        expect(validator.warnings?).to be true
       end
     end
 
     describe "warnings attribute" do
       it "returns the relevant warnings" do
-        expect(recruitment_banner.warnings).to eq({ "Banner 2" => ["refers to a path /email-signup which is not currently live on gov.uk"] })
+        expect(validator.warnings).to eq({ "Banner 2" => ["refers to a path /email-signup which is not currently live on gov.uk"] })
       end
     end
   end


### PR DESCRIPTION
Adds config and partials for the global banner (the non-emergency banner using this component: https://components.publishing.service.gov.uk/component-guide/global_banner)

Previously this component and the handling code was entirely within [static](https://github.com/alphagov/static), this PR adds the ability for non-static-based apps to use the global banners. A follow-up [PR](https://github.com/alphagov/static/pull/3561) will remove static's internal code and replace it with calls to this gem, so that this becomes the one place for configuration of the global banner for apps whether or not they rely on static.

https://trello.com/c/RqkCbWDD/394-add-global-banner-handling-to-govukwebbanners