### PR TITLE
Add HMRC web banners 03-01-25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For typos, release a patch version.
 
 ## UNRELEASED
 
+* Add configuration for "HMRC banner 03/01/2025"
 * Add emergency banner support ([PR #22](https://github.com/alphagov/govuk_web_banners/pull/22))
 
 ## 0.2.0

--- a/config/govuk_web_banners/recruitment_banners.yml
+++ b/config/govuk_web_banners/recruitment_banners.yml
@@ -45,3 +45,19 @@ banners:
     - /business-finance-support
   start_date: 11/11/2024
   end_date: 06/01/2025
+- name: HMRC banner 03/01/2025
+  suggestion_text: "Help improve GOV.UK"
+  suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"
+  survey_url: https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_74GjifgnGv6GsMC?Source=BannerList_HMRC_CCG_Compliance
+  page_paths:
+    # government-frontend
+    - /government/collections/tax-compliance-detailed-information
+    - /government/collections/hm-revenue-and-customs-compliance-checks-factsheets
+    - /difficulties-paying-hmrc
+    - /tax-help
+    - /get-help-hmrc-extra-support
+    - /guidance/voluntary-and-community-sector-organisations-who-can-give-you-extra-support
+    - /tax-appeals
+    - /guidance/tax-disputes-alternative-dispute-resolution-adr
+  start_date: 03/01/2025
+  end_date: 31/01/2025


### PR DESCRIPTION
## What
Add HMRC web banners to go live on 3rd January 2025

[Trello card](https://trello.com/c/UsOMHTG3/1662-user-research-banner-request-hmrc-kyle-magee)
