### PR TITLE
Add UKVI web banner 30/12/2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For typos, release a patch version.
 
 ## UNRELEASED
 
+* Add configuration for "UKVI banner 30/12/2025"
 * Add configuration for "HMRC banner 03/01/2025"
 * Add emergency banner support ([PR #22](https://github.com/alphagov/govuk_web_banners/pull/22))
 

--- a/config/govuk_web_banners/recruitment_banners.yml
+++ b/config/govuk_web_banners/recruitment_banners.yml
@@ -61,3 +61,15 @@ banners:
     - /guidance/tax-disputes-alternative-dispute-resolution-adr
   start_date: 03/01/2025
   end_date: 31/01/2025
+- name: UKVI banner 30/12/2025
+  suggestion_text: "Help improve GOV.UK"
+  suggestion_link_text: "Take part in user research (opens in a new tab)"
+  survey_url: https://surveys.publishing.service.gov.uk/s/XYVRGN/
+  page_paths:
+    # frontend
+    - /contact-ukvi-inside-outside-uk
+    # collections
+    - /browse/visas-immigration
+    - /government/organisations/uk-visas-and-immigration
+  start_date: 30/12/2024
+  end_date: 27/01/2025


### PR DESCRIPTION
## What

Add UKVI web banners to go live on 30 December 2024

[Trello card](https://trello.com/c/T2PlxBdl/3146-put-live-govuk-user-research-banner-requests-govuk-contact-ukvi)