### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ Include a link to your pull request.
 When adding a new banner to gov.uk page, release a minor version.
 For typos, release a patch version.
 
-## UNRELEASED
+## 0.3.0
 
-* Add configuration for "UKVI banner 30/12/2025"
-* Add configuration for "HMRC banner 03/01/2025"
+* Add configuration for "UKVI banner 30/12/2025" ([PR #37](https://github.com/alphagov/govuk_web_banners/pull/37))
+* Add configuration for "HMRC banner 03/01/2025" ([PR #36](https://github.com/alphagov/govuk_web_banners/pull/36))
 * Add emergency banner support ([PR #22](https://github.com/alphagov/govuk_web_banners/pull/22))
 
 ## 0.2.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_web_banners (0.2.0)
+    govuk_web_banners (0.3.0)
       govuk_app_config
       govuk_publishing_components
       rails (>= 7)

--- a/lib/govuk_web_banners/version.rb
+++ b/lib/govuk_web_banners/version.rb
@@ -1,3 +1,3 @@
 module GovukWebBanners
-  VERSION = "0.2.0".freeze
+  VERSION = "0.3.0".freeze
 end


### PR DESCRIPTION
* Add configuration for UKVI banner 30/12/2025 ([PR #37](https://github.com/alphagov/govuk_web_banners/pull/37))
* Add configuration for HMRC banner 03/01/2025 ([PR #36](https://github.com/alphagov/govuk_web_banners/pull/36))
* Add emergency banner support ([PR #22](https://github.com/alphagov/govuk_web_banners/pull/22))