### PR TITLE
Remove configuration for AI banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Include a link to your pull request.
 When adding a new banner to gov.uk page, release a minor version.
 For typos, release a patch version.
 
+## UNRELEASED
+* Remove configuration for "AI banner 11/11/2024"
+
 ## 0.3.0
 
 * Add configuration for "UKVI banner 30/12/2025" ([PR #37](https://github.com/alphagov/govuk_web_banners/pull/37))

--- a/config/govuk_web_banners/recruitment_banners.yml
+++ b/config/govuk_web_banners/recruitment_banners.yml
@@ -16,35 +16,6 @@
 # Note that this file must contain a valid banners array, so if there are no banners
 # currently included, the file should at least contain banners: []
 banners:
-- name: AI banner 11/11/2024
-  suggestion_text: "Help improve GOV.UK"
-  suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"
-  survey_url: https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_2bggmg6xlelrO0S
-  page_paths:
-    # government frontend:
-    - /self-assessment-tax-returns
-    - /working-for-yourself
-    - /self-employed-records
-    - /expenses-if-youre-self-employed
-    - /first-company-accounts-and-return
-    - /what-is-the-construction-industry-scheme
-    - /capital-allowances
-    - /simpler-income-tax-cash-basis
-    - /expenses-and-benefits-a-to-z
-    - /capital-gains-tax
-    - /directors-loans
-    - /self-assessment-tax-return-forms
-    - /running-a-limited-company
-    - /calculate-tax-on-company-cars
-    - /introduction-to-business-rates
-    - /calculate-your-business-rates
-    - /apply-for-business-rate-relief
-    - /stop-being-self-employed
-    - /tax-codes
-    # finder-frontend:
-    - /business-finance-support
-  start_date: 11/11/2024
-  end_date: 06/01/2025
 - name: HMRC banner 03/01/2025
   suggestion_text: "Help improve GOV.UK"
   suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"


### PR DESCRIPTION
Remove configuration for AI banner that went live on 11/11/2024

Trello card: https://trello.com/c/ssZmGS3k/3142-confirm-that-the-ai-user-research-banner-is-down-january-6th-2025