### PR TITLE
Remove the `govuk-width-container` CSS class from recruitment banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ When adding a new banner to gov.uk page, release a minor version.
 For typos, release a patch version.
 
 ## UNRELEASED
+
 * Remove configuration for "AI banner 11/11/2024"
+* Remove the `govuk-width-container` CSS class from recruitment banner ([PR #44](https://github.com/alphagov/govuk_web_banners/pull/44))
 
 ## 0.3.0
 

--- a/app/views/govuk_web_banners/_recruitment_banner.html.erb
+++ b/app/views/govuk_web_banners/_recruitment_banner.html.erb
@@ -1,6 +1,6 @@
 <% recruitment_banner = GovukWebBanners::RecruitmentBanner.for_path(request.path) %>
 <% if recruitment_banner.present? %>
-  <div class="govuk-width-container govuk-!-margin-top-4">
+  <div class="govuk-!-margin-top-4">
     <%= render "govuk_publishing_components/components/intervention", {
       new_tab: true,
       suggestion_text: recruitment_banner.suggestion_text,


### PR DESCRIPTION
## What

Remove the `govuk-width-container` CSS class from recruitment banner

## Why

The `govuk-width-container` is not required, the layout classes from the design system can be added in each application where the govuk_web_banner is used.

This will help improve the spacing on mobile and avoid extra spacing to the left and right of the component.

https://design-system.service.gov.uk/styles/layout/#common-layouts

## Visual Changes

Page: https://www.gov.uk/government/collections/tax-compliance-detailed-information

| Before | After |
| --- | --- |
| ![banner-before](https://github.com/user-attachments/assets/afd45068-f63d-444a-a146-f6796ddb1810) | ![banner-after](https://github.com/user-attachments/assets/26f5346f-55ee-437e-92ba-5f7573397c57) |

