### PR TITLE
Remove configuration for HMRC banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For typos, release a patch version.
 
 ## Unreleased
 
+* Remove configuration for "HMRC banner 03/01/2025" ([PR #53](https://github.com/alphagov/govuk_web_banners/pull/53))
 * Gem updates ([PR #50](https://github.com/alphagov/govuk_web_banners/pull/50))
 
 ## 0.4.0

--- a/config/govuk_web_banners/recruitment_banners.yml
+++ b/config/govuk_web_banners/recruitment_banners.yml
@@ -16,22 +16,6 @@
 # Note that this file must contain a valid banners array, so if there are no banners
 # currently included, the file should at least contain banners: []
 banners:
-- name: HMRC banner 03/01/2025
-  suggestion_text: "Help improve GOV.UK"
-  suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"
-  survey_url: https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_74GjifgnGv6GsMC?Source=BannerList_HMRC_CCG_Compliance
-  page_paths:
-    # government-frontend
-    - /government/collections/tax-compliance-detailed-information
-    - /government/collections/hm-revenue-and-customs-compliance-checks-factsheets
-    - /difficulties-paying-hmrc
-    - /tax-help
-    - /get-help-hmrc-extra-support
-    - /guidance/voluntary-and-community-sector-organisations-who-can-give-you-extra-support
-    - /tax-appeals
-    - /guidance/tax-disputes-alternative-dispute-resolution-adr
-  start_date: 03/01/2025
-  end_date: 31/01/2025
 - name: UKVI banner 30/12/2025
   suggestion_text: "Help improve GOV.UK"
   suggestion_link_text: "Take part in user research (opens in a new tab)"


### PR DESCRIPTION
Remove configuration for HMRC banner that went live on 03/01/2025

Trello card: https://trello.com/c/dh9B71eB/3242-take-down-govuk-user-research-banner-hmrc-kyle-magee

