### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Include a link to your pull request.
 When adding a new banner to gov.uk page, release a minor version.
 For typos, release a patch version.
 
-## UNRELEASED
+## 1.0.0
 
 * Add global banner JS to js dependencies file ([PR #55](https://github.com/alphagov/govuk_web_banners/pull/55))
 * Add global banner support ([PR #34](https://github.com/alphagov/govuk_web_banners/pull/34))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_web_banners (0.4.0)
+    govuk_web_banners (1.0.0)
       govuk_app_config
       govuk_publishing_components
       rails (>= 7)

--- a/lib/govuk_web_banners/version.rb
+++ b/lib/govuk_web_banners/version.rb
@@ -1,3 +1,3 @@
 module GovukWebBanners
-  VERSION = "0.4.0".freeze
+  VERSION = "1.0.0".freeze
 end


### PR DESCRIPTION
* Add global banner JS to js dependencies file ([PR #55](https://github.com/alphagov/govuk_web_banners/pull/55))
* Add global banner support ([PR #34](https://github.com/alphagov/govuk_web_banners/pull/34))
* Remove configuration for "HMRC banner 03/01/2025" ([PR #53](https://github.com/alphagov/govuk_web_banners/pull/53))
* Gem updates ([PR #50](https://github.com/alphagov/govuk_web_banners/pull/50))
* Add two HMRC banners 13/02/2025 ([PR #54](https://github.com/alphagov/govuk_web_banners/pull/54))