### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Include a link to your pull request.
 When adding a new banner to gov.uk page, release a minor version.
 For typos, release a patch version.
 
+# Unreleased
+
+* Update the survey url and end date for "UKVI banner 30/12/2025"
+
 ## 1.0.0
 
 * Add global banner JS to js dependencies file ([PR #55](https://github.com/alphagov/govuk_web_banners/pull/55))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ Include a link to your pull request.
 When adding a new banner to gov.uk page, release a minor version.
 For typos, release a patch version.
 
-# Unreleased
+## 1.0.1
 
-* Update the survey url and end date for "UKVI banner 30/12/2025"
+* Update the survey url and end date for "UKVI banner 30/12/2025" ([PR #58](https://github.com/alphagov/govuk_web_banners/pull/58))
 
 ## 1.0.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_web_banners (1.0.0)
+    govuk_web_banners (1.0.1)
       govuk_app_config
       govuk_publishing_components
       rails (>= 7)

--- a/config/govuk_web_banners/recruitment_banners.yml
+++ b/config/govuk_web_banners/recruitment_banners.yml
@@ -3,7 +3,7 @@ banners:
 - name: UKVI banner 2025/12/30
   suggestion_text: "Help improve GOV.UK"
   suggestion_link_text: "Take part in user research (opens in a new tab)"
-  survey_url: https://surveys.publishing.service.gov.uk/s/XYVRGN/
+  survey_url: https://GDSUserResearch.optimalworkshop.com/treejack/335bbf3aad15329e77a9dc9ce8a79ee1
   page_paths:
     # frontend
     - /contact-ukvi-inside-outside-uk
@@ -11,7 +11,7 @@ banners:
     - /browse/visas-immigration
     - /government/organisations/uk-visas-and-immigration
   start_date: 2024/12/30
-  end_date: 2025/02/24
+  end_date: 2025/02/18
 - name: HMRC banner 2025/02/13
   suggestion_text: "Help improve GOV.UK"
   suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"

--- a/lib/govuk_web_banners/version.rb
+++ b/lib/govuk_web_banners/version.rb
@@ -1,3 +1,3 @@
 module GovukWebBanners
-  VERSION = "1.0.0".freeze
+  VERSION = "1.0.1".freeze
 end


### PR DESCRIPTION
## Release 1.0.1

* Update the survey url and end date for "UKVI banner 30/12/2025" ([PR #58](https://github.com/alphagov/govuk_web_banners/pull/58))