### PR TITLE
Add HMRC UR banner to required pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Include a link to your pull request.
 When adding a new banner to gov.uk page, release a minor version.
 For typos, release a patch version.
 
+## Unreleased
+
+* Add configuration for "HMRC banner 18/02/2025"
+
 ## 1.0.1
 
 * Update the survey url and end date for "UKVI banner 30/12/2025" ([PR #58](https://github.com/alphagov/govuk_web_banners/pull/58))

--- a/config/govuk_web_banners/recruitment_banners.yml
+++ b/config/govuk_web_banners/recruitment_banners.yml
@@ -44,3 +44,15 @@ banners:
     - /maternity-paternity-calculator
   start_date: 2025/02/13
   end_date: 2025/03/13
+- name: HMRC banner - Debt Management 2025/02/18
+  suggestion_text: "Help improve GOV.UK"
+  suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"
+  survey_url: https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_74GjifgnGv6GsMC?Source=BannerList_HMRC_Tax_Debt_Management
+  page_paths:
+    # government-frontend
+    - /guidance/find-out-how-to-pay-a-debt-to-hmrc-with-a-time-to-pay-arrangement
+    - /guidance/what-will-happen-if-you-do-not-pay-your-tax-bill
+    - /guidance/pay-taxes-penalties-and-enquiry-settlements
+    - /difficulties-paying-hmrc
+  start_date: 2025/02/18
+  end_date: 2025/03/18


### PR DESCRIPTION
Add configuration for HMRC UR banner.

[Trello card](https://trello.com/c/MDBh5yqZ/3268-put-live-govuk-user-research-banner-request-hmrc-debt-management-kyle)