### PR TITLE
fix same_time test

### DIFF
--- a/spec/units/govuk_web_banners/validators/global_banner_spec.rb
+++ b/spec/units/govuk_web_banners/validators/global_banner_spec.rb
@@ -86,6 +86,9 @@ RSpec.describe GovukWebBanners::Validators::GlobalBanner do
         YAML.load_file(Rails.root.join(fixtures_dir, "same_time_global_banners.yml"))
       end
 
+      before { travel_to Time.local(2025, 1, 10) }
+      after { travel_back }
+
       describe ".valid?" do
         it "returns true" do
           expect(validator.valid?).to be true


### PR DESCRIPTION
- This test should run at a fixed time (before the start date of the relevant configs) so that it doesn't accidentally throw other errors (like expiries) into the output message and confuse the tests.