### PR TITLE
Release 1.1.3 (second attempt)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_web_banners (1.1.2)
+    govuk_web_banners (1.1.3)
       govuk_app_config
       govuk_publishing_components
       rails (>= 7)

--- a/lib/govuk_web_banners/version.rb
+++ b/lib/govuk_web_banners/version.rb
@@ -1,3 +1,3 @@
 module GovukWebBanners
-  VERSION = "1.1.2".freeze
+  VERSION = "1.1.3".freeze
 end


### PR DESCRIPTION
Missing from [9ad32133](https://github.com/alphagov/govuk_web_banners/pull/77/commits/9ad321336860cc027168c4990bff079e877e3fb6)

## Release 1.1.3
Remove stale banner configs:

- [UKVI banner 2025/12/30](https://trello.com/c/bSRgeB6b/3364-take-down-govuk-user-research-banner-ukvi)
- [HMRC banner 2025/02/13](https://trello.com/c/E5gBPIZ4/3362-take-down-govuk-user-research-banner-hmrc-ines-hmrc-banner-2025-02-13?filter=label:Banner%20for%20research)
- HMRC banner (employers) 2025/02/13