### PR TITLE
Remove HMRC banner 2025/02/25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Include a link to your pull request.
 When adding a new banner to gov.uk page, release a minor version.
 For typos, release a patch version.
 
+## Unreleased
+
+Remove configuration for HMRC banner 2025/02/25
+
 ## 1.1.3
 
 * Remove expired config for UKVI banner 2025/12/30, HMRC banner 2025/02/13 and HMRC banner (employers) 2025/02/13 ([PR #77]https://github.com/alphagov/govuk_web_banners/pull/77)

--- a/config/govuk_web_banners/recruitment_banners.yml
+++ b/config/govuk_web_banners/recruitment_banners.yml
@@ -12,13 +12,3 @@ banners:
     - /difficulties-paying-hmrc
   start_date: 2025/02/18
   end_date: 2025/04/15
-- name: HMRC banner 2025/02/25
-  suggestion_text: "Help improve GOV.UK"
-  suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"
-  survey_url: https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_74GjifgnGv6GsMC?Source=BannerList_HMRC_Apply_for_alcoholic_producers_approval
-  page_paths:
-    # government-frontend
-    - /guidance/check-if-you-need-an-alcoholic-products-producer-approval-appa
-    - /guidance/apply-for-an-alcoholic-products-producer-approval-appa
-  start_date: 2025/02/25
-  end_date: 2025/03/25


### PR DESCRIPTION
Trello card: https://trello.com/c/bObiRGJi/3389-take-down-govuk-user-research-banner-hmrc-ben-bywater