### PR TITLE
Add configuration for HMRC banner 2025/10/17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Include a link to your pull request.
 When adding a new banner to gov.uk page, release a minor version.
 For typos, release a patch version.
 
+# 1.15.0
+
+* Add configuration for HMRC banner 2025/10/17 ([PR #172](https://github.com/alphagov/govuk_web_banners/pull/172))
+
 # 1.14.0
 
 * Add configuration for "HMRC banner 2025/10/10" ([PR #169](https://github.com/alphagov/govuk_web_banners/pull/169))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_web_banners (1.14.0)
+    govuk_web_banners (1.15.0)
       govuk_app_config (>= 9)
       govuk_publishing_components
       rails (>= 7)

--- a/config/govuk_web_banners/recruitment_banners.yml
+++ b/config/govuk_web_banners/recruitment_banners.yml
@@ -100,3 +100,39 @@ banners:
     - /government/publications/self-assessment-partnership-short-sa104s
   start_date: 2025/10/10
   end_date: 2025/11/07
+- name: HMRC banner - Simple Assessment PAYE CI Request 25/10/17
+  suggestion_text: "Help improve GOV.UK"
+  suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"
+  survey_url: https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_74GjifgnGv6GsMC?Source=BannerList_HMRC_Tax_On_Pension
+  page_paths:
+    # frontend
+    - /tax-on-pension
+  start_date: 2025/10/17
+  end_date: 2025/12/12
+- name: HMRC banner - Simple Assessment PAYE CI Request 25/10/17
+  suggestion_text: "Help improve GOV.UK"
+  suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"
+  survey_url: https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_74GjifgnGv6GsMC?Source=BannerList_HMRC_Check_Simple_Assessment
+  page_paths:
+    # frontend
+    - /check-simple-assessment
+  start_date: 2025/10/17
+  end_date: 2025/12/12
+- name: HMRC banner - Simple Assessment PAYE CI Request 25/10/17
+  suggestion_text: "Help improve GOV.UK"
+  suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"
+  survey_url: https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_74GjifgnGv6GsMC?Source=BannerList_HMRC_Simple_Assessment
+  page_paths:
+    # frontend
+    - /simple-assessment
+  start_date: 2025/10/17
+  end_date: 2025/12/12
+- name: HMRC banner - Simple Assessment PAYE CI Request 25/10/17
+  suggestion_text: "Help improve GOV.UK"
+  suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"
+  survey_url: https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_74GjifgnGv6GsMC?Source=BannerList_HMRC_Apply_Tax_Free_Interest_On_Savings
+  page_paths:
+    # frontend
+    - /apply-tax-free-interest-on-savings
+  start_date: 2025/10/17
+  end_date: 2025/12/12

--- a/lib/govuk_web_banners/version.rb
+++ b/lib/govuk_web_banners/version.rb
@@ -1,3 +1,3 @@
 module GovukWebBanners
-  VERSION = "1.14.0".freeze
+  VERSION = "1.15.0".freeze
 end


### PR DESCRIPTION
## What

Add user research banners for HMRC, there is a separate entry for each banner in `frontend` as each survey has a unique query parameter.

## Why

Jira card: https://gov-uk.atlassian.net/browse/URB-12