### PR TITLE
Add cooldown to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: daily
     cooldown:
       default-days: 3
+      exclude:
+        - govuk_*
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Adds cooldown of 3 days to avoid unstable or compromised releases