### PR TITLE
[NAV-18905] Pin SHAs for third-party actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         ref: ${{ inputs.ref || github.ref }}
-    - uses: ruby/setup-ruby@v1.308.0
+    - uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
@@ -66,10 +66,10 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v6
-    - uses: ruby/setup-ruby@v1.308.0
+    - uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
       with:
         rubygems: latest
-    - uses: actions/setup-node@v6.4.0
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: lts/* # use the latest LTS release
     - env:


### PR DESCRIPTION
Pin non-alphagov/non-github actions

-As per policy: https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#pin-untrusted-github-actions-to-a-commit-sha

JIRA Card: https://gov-uk.atlassian.net/browse/NAV-18905
