### PR TITLE
Add configuration for HMRC banner 2026/07/06 URB-41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Include a link to your pull request.
 When adding a new banner to gov.uk page, release a minor version.
 For typos, release a patch version.
 
+# 1.37.2
+
+* Add configuration for HMRC banner 2026/07/06 URB-41 [PR #275](https://github.com/alphagov/govuk_web_banners/pull/275)
+
 # 1.37.1
 
 * Add charity banner to smart answer [PR #278](https://github.com/alphagov/govuk_web_banners/pull/278)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_web_banners (1.37.1)
+    govuk_web_banners (1.37.2)
       govuk_app_config (>= 9)
       govuk_publishing_components
       rails (>= 7)

--- a/config/govuk_web_banners/recruitment_banners.yml
+++ b/config/govuk_web_banners/recruitment_banners.yml
@@ -137,3 +137,16 @@ banners:
     - /prepare-charitys-annual-accounts/y/no/over-1-million
   start_date: 2026/07/03
   end_date: 2026/07/24
+- name: (URB-41) HMRC banner 2026/07/06
+  suggestion_text: "Help improve GOV.UK"
+  suggestion_link_text: "Sign up to take part in user research (opens in a new tab)"
+  survey_url: https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_74GjifgnGv6GsMC?Source=BannerList_HMRC_P800_over_under_payment_TAD
+  page_paths:
+    # frontend
+    - /tax-overpayments-and-underpayments/if-youre-due-a-refund
+    - /pay-p800-tax-calculation
+    - /guidance/claim-an-income-tax-refund-by-post
+    - /tax-codes/emergency-tax-codes
+    - /pay-tax-debit-credit-card
+  start_date: 2026/07/06
+  end_date: 2026/08/31

--- a/lib/govuk_web_banners/version.rb
+++ b/lib/govuk_web_banners/version.rb
@@ -1,3 +1,3 @@
 module GovukWebBanners
-  VERSION = "1.37.1".freeze
+  VERSION = "1.37.2".freeze
 end


### PR DESCRIPTION
Jira card: https://gov-uk.atlassian.net/browse/URB-41

The ticket contains duplicate banners. HMRC banners 2026/07/06 will not be included for the following URLs:
/tax-overpayments-and-underpayments
/tax-overpayments-and-underpayments/if-you-owe-tax
/claim-tax-refund