### PR TITLE
Remove margin top from banners

### DIFF
--- a/app/views/govuk_web_banners/_emergency_banner.html.erb
+++ b/app/views/govuk_web_banners/_emergency_banner.html.erb
@@ -1,11 +1,11 @@
 <% emergency_banner = GovukWebBanners::EmergencyBanner.new %>
 <% if emergency_banner.active? %>
   <%= render "govuk_publishing_components/components/emergency_banner", {
-      campaign_class: emergency_banner.campaign_class,
-      heading: emergency_banner.heading,
-      link: emergency_banner.link,
-      link_text: emergency_banner.link_text,
-      short_description: emergency_banner.short_description,
-      homepage: local_assigns[:homepage] || false,
+    campaign_class: emergency_banner.campaign_class,
+    heading: emergency_banner.heading,
+    link: emergency_banner.link,
+    link_text: emergency_banner.link_text,
+    short_description: emergency_banner.short_description,
+    homepage: local_assigns[:homepage] || false,
   } %>
 <% end %>

--- a/app/views/govuk_web_banners/_global_banner.html.erb
+++ b/app/views/govuk_web_banners/_global_banner.html.erb
@@ -1,10 +1,10 @@
 <% global_banners = GovukWebBanners::GlobalBanner.for_path(request.path) %>
 <% if global_banners.any? %>
   <%= render "govuk_publishing_components/components/global_banner", {
-      title: global_banners.first.title,
-      title_href: global_banners.first.title_href,
-      text: global_banners.first.text,
-      always_visible: global_banners.first.always_visible,
-      banner_version: global_banners.first.version,
+    title: global_banners.first.title,
+    title_href: global_banners.first.title_href,
+    text: global_banners.first.text,
+    always_visible: global_banners.first.always_visible,
+    banner_version: global_banners.first.version,
   } %>
 <% end %>

--- a/app/views/govuk_web_banners/_recruitment_banner.html.erb
+++ b/app/views/govuk_web_banners/_recruitment_banner.html.erb
@@ -1,12 +1,10 @@
 <% recruitment_banner = GovukWebBanners::RecruitmentBanner.for_path(request.path) %>
 <% if recruitment_banner.present? %>
-  <div class="govuk-!-margin-top-4">
-    <%= render "govuk_publishing_components/components/intervention", {
-      new_tab: true,
-      suggestion_text: recruitment_banner.suggestion_text,
-      suggestion_link_text: recruitment_banner.suggestion_link_text,
-      suggestion_link_url: recruitment_banner.survey_url,
-      image: recruitment_banner.image,
-    } %>
-  </div>
+  <%= render "govuk_publishing_components/components/intervention", {
+    new_tab: true,
+    suggestion_text: recruitment_banner.suggestion_text,
+    suggestion_link_text: recruitment_banner.suggestion_link_text,
+    suggestion_link_url: recruitment_banner.survey_url,
+    image: recruitment_banner.image,
+  } %>
 <% end %>

--- a/app/views/govuk_web_banners/_uprating_banner.html.erb
+++ b/app/views/govuk_web_banners/_uprating_banner.html.erb
@@ -1,9 +1,7 @@
 <% uprating_banner = GovukWebBanners::UpratingBanner.for_path(request.path) %>
 <% if uprating_banner.present? %>
-  <div class="govuk-!-margin-top-4">
-    <%= render "govuk_publishing_components/components/notice", {
-      title: uprating_banner.text,
-      show_banner_title: true
-    } %>
-  </div>
+  <%= render "govuk_publishing_components/components/notice", {
+    title: uprating_banner.text,
+    show_banner_title: true
+  } %>
 <% end %>


### PR DESCRIPTION
## What / why

- removes the wrapping divs with margin top classes around the recruitment banner (intervention component) and uprating banner (notice component)
- this is causing an extra gap in finder-frontend with the recruitment banner, and goes against our general layout/component standard of a margin bottom approach

