### PR TITLE
Add configuration for HMRC banner 2026/07/06 URB-41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Include a link to your pull request.
 When adding a new banner to gov.uk page, release a minor version.
 For typos, release a patch version.
 
+# 1.37.4
+
+* Add configuration for HMRC banner 2026/07/06 URB-41 [PR #288](https://github.com/alphagov/govuk_web_banners/pull/288)
+
 # 1.37.3
 
 * Add configuration for HMRC CXD banner 2026/07/13 URB-42 [PR #283](https://github.com/alphagov/govuk_web_banners/pull/283)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_web_banners (1.37.3)
+    govuk_web_banners (1.37.4)
       govuk_app_config (>= 9)
       govuk_publishing_components
       rails (>= 7)

--- a/config/govuk_web_banners/recruitment_banners.yml
+++ b/config/govuk_web_banners/recruitment_banners.yml
@@ -83,9 +83,6 @@ banners:
   survey_url: https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_74GjifgnGv6GsMC?Source=BannerList_HMRC_MTD_VAT_Repayments
   page_paths:
     # frontend
-    - /claim-tax-refund
-    - /tax-overpayments-and-underpayments
-    - /tax-overpayments-and-underpayments/if-you-owe-tax
     - /self-assessment-tax-returns/claiming-a-tax-refund
     - /guidance/claim-a-refund-of-construction-industry-scheme-deductions-if-youre-a-limited-company
   start_date: 2026/06/17
@@ -143,6 +140,9 @@ banners:
   survey_url: https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_74GjifgnGv6GsMC?Source=BannerList_HMRC_P800_over_under_payment_TAD
   page_paths:
     # frontend
+    - /claim-tax-refund
+    - /tax-overpayments-and-underpayments
+    - /tax-overpayments-and-underpayments/if-you-owe-tax
     - /tax-overpayments-and-underpayments/if-youre-due-a-refund
     - /pay-p800-tax-calculation
     - /guidance/claim-an-income-tax-refund-by-post

--- a/lib/govuk_web_banners/version.rb
+++ b/lib/govuk_web_banners/version.rb
@@ -1,3 +1,3 @@
 module GovukWebBanners
-  VERSION = "1.37.3".freeze
+  VERSION = "1.37.4".freeze
 end


### PR DESCRIPTION
Jira card: https://gov-uk.atlassian.net/browse/URB-41

The ticket removes and updates the following duplicate banners: 
/tax-overpayments-and-underpayments
/tax-overpayments-and-underpayments/if-you-owe-tax
/claim-tax-refund